### PR TITLE
Multi-node parallel option for mc.cores

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,4 +24,4 @@ Suggests:
     knitr,
     rmarkdown
 VignetteBuilder: knitr
-RoxygenNote: 5.0.1
+RoxygenNote: 6.1.1

--- a/R/main.R
+++ b/R/main.R
@@ -14,16 +14,16 @@
 #' @param dtm An object of class "\link[tm]{DocumentTermMatrix}" with
 #'   term-frequency weighting or an object coercible to a
 #'   "\link[slam]{simple_triplet_matrix}" with integer entries.
-#' @param topics Vvector with number of topics to compare different models.
+#' @param topics Vector with number of topics to compare different models.
 #' @param metrics String or vector of possible metrics: "Griffiths2004",
 #'   "CaoJuan2009", "Arun2010", "Deveaud2014".
 #' @param method The method to be used for fitting; see \link[topicmodels]{LDA}.
 #' @param control A named list of the control parameters for estimation or an
 #'   object of class "\linkS4class{LDAcontrol}".
-#' @param mc.cores Integer or cluster; the number of CPU cores to processes models
+#' @param mc.cores NA, integer or, cluster; the number of CPU cores to process models
 #'   simultaneously. If an integer, create a cluster on the local machine. If a
 #'   cluster, use but don't destroy it (allows multiple-node clusters). Defaults to
-#'   auto-detection of number of cores.
+#'   NA, which triggers auto-detection of number of cores on the local machine.
 #' @param verbose If false (default), supress all warnings and additional
 #'   information.
 #' @param libpath Path to R packages (use only if your R installation can't find

--- a/R/main.R
+++ b/R/main.R
@@ -75,7 +75,7 @@ FindTopicsNumber <- function(dtm, topics = seq(10, 40, by = 10),
   # Parallel setup
   if (any(class(mc.cores) == "cluster")) {
     cl <- mc.cores
-  } else if (class(mc.cores == "integer")) {
+  } else if (isTRUE(class(mc.cores) == "integer")) {
     cl <- parallel::makeCluster(mc.cores)
   } else {
     cl <- parallel::makeCluster(parallel::detectCores())

--- a/man/Deveaud2014.Rd
+++ b/man/Deveaud2014.Rd
@@ -10,4 +10,3 @@ Deveaud2014(models)
 Deveaud2014
 }
 \keyword{internal}
-

--- a/man/FindTopicsNumber.Rd
+++ b/man/FindTopicsNumber.Rd
@@ -6,7 +6,7 @@
 \usage{
 FindTopicsNumber(dtm, topics = seq(10, 40, by = 10),
   metrics = "Griffiths2004", method = "Gibbs", control = list(),
-  mc.cores = 1L, verbose = FALSE, libpath = NULL)
+  mc.cores = NA, verbose = FALSE, libpath = NULL)
 }
 \arguments{
 \item{dtm}{An object of class "\link[tm]{DocumentTermMatrix}" with
@@ -23,8 +23,10 @@ term-frequency weighting or an object coercible to a
 \item{control}{A named list of the control parameters for estimation or an
 object of class "\linkS4class{LDAcontrol}".}
 
-\item{mc.cores}{Integer; The number of CPU cores to processes models
-simultaneously.}
+\item{mc.cores}{NA, integer or, cluster; the number of CPU cores to process models
+simultaneously. If an integer, create a cluster on the local machine. If a
+cluster, use but don't destroy it (allows multiple-node clusters). Defaults to
+NA, which triggers auto-detection of number of cores on the local machine.}
 
 \item{verbose}{If false (default), supress all warnings and additional
 information.}
@@ -53,4 +55,3 @@ FindTopicsNumber(dtm, topics = 2:10, metrics = "Arun2010", mc.cores = 1L)
 }
 
 }
-

--- a/man/FindTopicsNumber_plot.Rd
+++ b/man/FindTopicsNumber_plot.Rd
@@ -27,4 +27,3 @@ FindTopicsNumber_plot(optimal.topics)
 }
 
 }
-

--- a/man/ldatuning.Rd
+++ b/man/ldatuning.Rd
@@ -8,4 +8,3 @@
 \description{
 ldatuning: Tuning of the LDA models parameters
 }
-


### PR DESCRIPTION
Changed mc.cores to allow for multi-node processing. There are now 3 options for mc.cores: (1) an object of type "cluster", which can be a multi-node cluster; (2) an integer, which will be used as the number of cores for a single-node cluster; (3) NA [or any other class] as the new default, which will result in a single-node cluster having the number of cores detected by parallel::detectCores. #3 is an implementation of a to-do item.

If a cluster is passed as mc.cores, the cluster isn't stopped after processing takes place.

In addition, this commit implements the to-do item where the topics vector is sorted in descending order for optimal parallelization.